### PR TITLE
feature: budget periods recursion

### DIFF
--- a/lib/budgie/tracking/budget.ex
+++ b/lib/budgie/tracking/budget.ex
@@ -12,6 +12,8 @@ defmodule Budgie.Tracking.Budget do
 
     belongs_to :creator, Budgie.Accounts.User
 
+    has_many :periods, Budgie.Tracking.BudgetPeriod
+
     timestamps(type: :utc_datetime)
   end
 

--- a/lib/budgie/tracking/budget.ex
+++ b/lib/budgie/tracking/budget.ex
@@ -29,6 +29,27 @@ defmodule Budgie.Tracking.Budget do
       message: "must end after start date"
     )
     |> unique_constraint([:buget_id, :start_date])
+    |> validate_date_month_boundaries()
+  end
+
+  def validate_date_month_boundaries(%Ecto.Changeset{valid?: false} = cs), do: cs
+
+  def validate_date_month_boundaries(%Ecto.Changeset{} = cs) do
+    start_date = get_field(cs, :start_date)
+    end_date = get_field(cs, :end_date)
+
+    cs =
+      if start_date != Date.beginning_of_month(start_date) do
+	add_error(cs, :start_date, "must be the beginning of a month")
+      else
+	cs
+      end
+
+    if end_date != Date.end_of_month(end_date) do
+      add_error(cs, :end_date, "must be the end of a month")
+    else
+      cs
+    end
   end
 end
 

--- a/lib/budgie/tracking/budget.ex
+++ b/lib/budgie/tracking/budget.ex
@@ -29,6 +29,33 @@ defmodule Budgie.Tracking.Budget do
       message: "must end after start date"
     )
     |> Budgie.Validations.validate_date_month_boundaries()
+    |> add_periods()
+  end
+
+  defp add_periods(%{valid?: false} = changeset), do: changeset
+
+  defp add_periods(changeset) do
+    start_date = Ecto.Changeset.get_field(changeset, :start_date)
+    end_date = Ecto.Changeset.get_field(changeset, :end_date)
+
+    changeset
+    |> Ecto.Changeset.change(%{periods: months_between(start_date, end_date)})
+    |> Ecto.Changeset.cast_assoc(:periods)
+  end
+
+  def months_between(start_date, end_date, acc \\ []) do
+    end_of_month = Date.end_of_month(start_date)
+
+    # If we have reached the end of the timespan
+    if not Date.after?(end_date, end_of_month) do
+      Enum.reverse([%{start_date: start_date, end_date: end_of_month} | acc])
+    else
+      months_between(
+	Date.add(end_of_month, 1),
+	end_date,
+	[%{start_date: start_date, end_date: end_of_month} | acc]
+      )
+    end
   end
 end
 

--- a/lib/budgie/tracking/budget.ex
+++ b/lib/budgie/tracking/budget.ex
@@ -28,6 +28,7 @@ defmodule Budgie.Tracking.Budget do
       name: :budget_end_after_start,
       message: "must end after start date"
     )
+    |> unique_constraint([:buget_id, :start_date])
   end
 end
 

--- a/lib/budgie/tracking/budget.ex
+++ b/lib/budgie/tracking/budget.ex
@@ -28,28 +28,7 @@ defmodule Budgie.Tracking.Budget do
       name: :budget_end_after_start,
       message: "must end after start date"
     )
-    |> unique_constraint([:buget_id, :start_date])
-    |> validate_date_month_boundaries()
-  end
-
-  def validate_date_month_boundaries(%Ecto.Changeset{valid?: false} = cs), do: cs
-
-  def validate_date_month_boundaries(%Ecto.Changeset{} = cs) do
-    start_date = get_field(cs, :start_date)
-    end_date = get_field(cs, :end_date)
-
-    cs =
-      if start_date != Date.beginning_of_month(start_date) do
-	add_error(cs, :start_date, "must be the beginning of a month")
-      else
-	cs
-      end
-
-    if end_date != Date.end_of_month(end_date) do
-      add_error(cs, :end_date, "must be the end of a month")
-    else
-      cs
-    end
+    |> Budgie.Validations.validate_date_month_boundaries()
   end
 end
 

--- a/lib/budgie/tracking/budget_period.ex
+++ b/lib/budgie/tracking/budget_period.ex
@@ -1,0 +1,21 @@
+defmodule Budgie.Tracking.BudgetPeriod do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "budget_periods" do
+    field :start_date, :date
+    field :end_date, :date
+    field :budget_id, :binary_id
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(budget_period, attrs) do
+    budget_period
+    |> cast(attrs, [:start_date, :end_date])
+    |> validate_required([:start_date, :end_date])
+  end
+end

--- a/lib/budgie/tracking/budget_period.ex
+++ b/lib/budgie/tracking/budget_period.ex
@@ -7,7 +7,7 @@ defmodule Budgie.Tracking.BudgetPeriod do
   schema "budget_periods" do
     field :start_date, :date
     field :end_date, :date
-    field :budget_id, :binary_id
+    belongs_to :budget, Budgie.Tracking.Budget
 
     timestamps(type: :utc_datetime)
   end
@@ -15,7 +15,12 @@ defmodule Budgie.Tracking.BudgetPeriod do
   @doc false
   def changeset(budget_period, attrs) do
     budget_period
-    |> cast(attrs, [:start_date, :end_date])
-    |> validate_required([:start_date, :end_date])
+    |> cast(attrs, [:start_date, :end_date, :budget_id])
+    |> validate_required([:start_date, :end_date, :budget_id])
+    |> check_constraint(:end_date,
+      name: :end_after_start,
+      message: "must end after start date"
+    )
+    |> unique_constraint([:budget_id, :start_date])
   end
 end

--- a/lib/budgie/tracking/budget_period.ex
+++ b/lib/budgie/tracking/budget_period.ex
@@ -22,5 +22,26 @@ defmodule Budgie.Tracking.BudgetPeriod do
       message: "must end after start date"
     )
     |> unique_constraint([:budget_id, :start_date])
+    |> validate_date_month_boundaries()
+  end
+
+  def validate_date_month_boundaries(%Ecto.Changeset{valid?: false} = cs), do: cs
+
+  def validate_date_month_boundaries(%Ecto.Changeset{} = cs) do
+    start_date = get_field(cs, :start_date)
+    end_date = get_field(cs, :end_date)
+
+    cs =
+      if start_date != Date.beginning_of_month(start_date) do
+        add_error(cs, :start_date, "must be the beginning of a month")
+      else
+        cs
+      end
+
+    if end_date != Date.end_of_month(end_date) do
+      add_error(cs, :end_date, "must be the end of a month")
+    else
+      cs
+    end
   end
 end

--- a/lib/budgie/tracking/budget_period.ex
+++ b/lib/budgie/tracking/budget_period.ex
@@ -22,26 +22,6 @@ defmodule Budgie.Tracking.BudgetPeriod do
       message: "must end after start date"
     )
     |> unique_constraint([:budget_id, :start_date])
-    |> validate_date_month_boundaries()
-  end
-
-  def validate_date_month_boundaries(%Ecto.Changeset{valid?: false} = cs), do: cs
-
-  def validate_date_month_boundaries(%Ecto.Changeset{} = cs) do
-    start_date = get_field(cs, :start_date)
-    end_date = get_field(cs, :end_date)
-
-    cs =
-      if start_date != Date.beginning_of_month(start_date) do
-        add_error(cs, :start_date, "must be the beginning of a month")
-      else
-        cs
-      end
-
-    if end_date != Date.end_of_month(end_date) do
-      add_error(cs, :end_date, "must be the end of a month")
-    else
-      cs
-    end
+    |> Budgie.Validations.validate_date_month_boundaries()
   end
 end

--- a/lib/budgie/validations.ex
+++ b/lib/budgie/validations.ex
@@ -1,0 +1,23 @@
+defmodule Budgie.Validations do
+  import Ecto.Changeset
+
+  def validate_date_month_boundaries(%Ecto.Changeset{valid?: false} = cs), do: cs
+
+  def validate_date_month_boundaries(%Ecto.Changeset{} = cs) do
+    start_date = get_field(cs, :start_date)
+    end_date = get_field(cs, :end_date)
+
+    cs =
+      if start_date != Date.beginning_of_month(start_date) do
+        add_error(cs, :start_date, "must be the beginning of a month")
+      else
+        cs
+      end
+
+    if end_date != Date.end_of_month(end_date) do
+      add_error(cs, :end_date, "must be the end of a month")
+    else
+      cs
+    end
+  end
+end

--- a/lib/budgie_web/live/budget_show_live.ex
+++ b/lib/budgie_web/live/budget_show_live.ex
@@ -30,7 +30,7 @@ defmodule BudgieWeb.BudgetShowLive do
     budget =
       Tracking.get_budget(id,
         user: socket.assigns.current_user,
-        preload: :creator
+        preload: [:creator, :periods]
       )
 
     if budget do

--- a/lib/budgie_web/live/budget_show_live.html.heex
+++ b/lib/budgie_web/live/budget_show_live.html.heex
@@ -57,6 +57,19 @@
   </div>
 </div>
 
+<div class="grid grid-cols-1 gap-4 mt-6">
+  <div
+    :for={period <- @budget.periods}
+    class="bg-white rounded shadow-sm p-4 cursor-pointer hover:shadow-md transition-shadow"
+  >
+    <div class="flex justify-between items-center mb-3">
+      <h3 class="font-medium text-gray-900">
+        {period.start_date}
+      </h3>
+    </div>
+  </div>
+</div>
+
 <.table id="transactions" rows={@transactions}>
   <:col :let={transaction} label="Description">{transaction.description}</:col>
   <:col :let={transaction} label="Date">{transaction.effective_date}</:col>

--- a/lib/budgie_web/live/create_budget_dialog.ex
+++ b/lib/budgie_web/live/create_budget_dialog.ex
@@ -29,11 +29,11 @@ defmodule BudgieWeb.CreateBudgetDialog do
   def handle_event("save", %{"budget" => params}, socket) do
     params = Map.put(params, "creator_id", socket.assigns.current_user.id)
 
-    with {:ok, %Budget{}} <- Tracking.create_budget(params) do
+    with {:ok, %Budget{} = budget} <- Tracking.create_budget(params) do
       socket =
         socket
         |> put_flash(:info, "Budget created")
-        |> push_navigate(to: ~p"/budgets", replace: true)
+        |> push_navigate(to: ~p"/budgets/#{budget}", replace: true)
 
       {:noreply, socket}
     else

--- a/priv/repo/migrations/20250421123312_create_budget_periods.exs
+++ b/priv/repo/migrations/20250421123312_create_budget_periods.exs
@@ -1,0 +1,21 @@
+defmodule Budgie.Repo.Migrations.CreateBudgetPeriods do
+  use Ecto.Migration
+
+  def change do
+    create table(:budget_periods, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :start_date, :date
+      add :end_date, :date
+      add :budget_id, references(:budgets, on_delete: :delete_all, type: :binary_id)
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:budget_periods, [:budget_id, :start_date])
+
+    create constraint(:budget_periods, :end_after_start,
+             check: "end_date > start_date",
+             comment: "Period must end after its start date"
+           )
+  end
+end

--- a/test/budgie/tracking/budget_period_test.exs
+++ b/test/budgie/tracking/budget_period_test.exs
@@ -1,0 +1,49 @@
+defmodule Budgie.Tracking.BudgetPeriodTest do
+  use Budgie.DataCase
+
+  alias Budgie.Tracking.BudgetPeriod
+
+  describe "changeset/2" do
+    test "fails when start date is after the beginning of the month" do
+      attrs = params_with_assocs(:budget_period, start_date: ~D[2025-01-05])
+
+      changeset = BudgetPeriod.changeset(%BudgetPeriod{}, attrs)
+
+      refute changeset.valid?
+
+      assert %{start_date: ["must be the beginning of a month"]} = errors_on(changeset)
+    end
+
+    test "fails when end date is before the end of the month" do
+      attrs = params_with_assocs(:budget_period, end_date: ~D[2025-01-15])
+
+      changeset = BudgetPeriod.changeset(%BudgetPeriod{}, attrs)
+
+      refute changeset.valid?
+
+      assert %{end_date: ["must be the end of a month"]} = errors_on(changeset)
+    end
+
+    test "fails when both start and end date are incorrect" do
+      attrs =
+        params_with_assocs(:budget_period, start_date: ~D[2025-01-05], end_date: ~D[2025-01-15])
+
+      changeset = BudgetPeriod.changeset(%BudgetPeriod{}, attrs)
+
+      refute changeset.valid?
+
+      assert %{
+               start_date: ["must be the beginning of a month"],
+               end_date: ["must be the end of a month"]
+             } = errors_on(changeset)
+    end
+
+    test "valid when start and end dates are correct" do
+      attrs = params_with_assocs(:budget_period)
+
+      changeset = BudgetPeriod.changeset(%BudgetPeriod{}, attrs)
+
+      assert changeset.valid?
+    end
+  end
+end

--- a/test/budgie/tracking_test.exs
+++ b/test/budgie/tracking_test.exs
@@ -47,7 +47,7 @@ defmodule Budgie.TrackingTest do
         )
 
       assert {:error, %Ecto.Changeset{} = changeset} = Tracking.create_budget(attrs)
-      assert %{end_date: ["must end after start date"]} = errors_on(changeset)
+      assert %{end_date: ["must be the end of a month"]} = errors_on(changeset)
 
       assert changeset.valid? == false
       # dbg(changeset)

--- a/test/budgie/tracking_test.exs
+++ b/test/budgie/tracking_test.exs
@@ -42,12 +42,12 @@ defmodule Budgie.TrackingTest do
     test "create_budget/1 with requires valid dates" do
       attrs =
         params_with_assocs(:budget,
-          start_date: ~D[2025-01-31],
-          end_date: ~D[2025-01-01]
+          start_date: ~D[2025-12-01],
+          end_date: ~D[2025-01-31]
         )
 
       assert {:error, %Ecto.Changeset{} = changeset} = Tracking.create_budget(attrs)
-      assert %{end_date: ["must be the end of a month"]} = errors_on(changeset)
+      assert %{end_date: ["must end after start date"]} = errors_on(changeset)
 
       assert changeset.valid? == false
       # dbg(changeset)

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -28,6 +28,14 @@ defmodule Budgie.Factory do
     }
   end
 
+  def budget_period_factory do
+    %Tracking.BudgetPeriod{
+      budget: build(:budget),
+      start_date: ~D[2025-01-01],
+      end_date: ~D[2025-01-31]
+    }
+  end
+
   def budget_transaction_factory do
     %Tracking.BudgetTransaction{
       effective_date: ~D[2025-01-01],


### PR DESCRIPTION
This pull request introduces functionality for managing budget periods in the Budgie application. It includes changes to the schema, validations, migrations, and UI to support the creation, association, and display of budget periods. Additionally, comprehensive tests have been added to ensure the correctness of the new features.

### Schema and Data Management Enhancements:
* Added a `has_many` relationship between `Budgie.Tracking.Budget` and `Budgie.Tracking.BudgetPeriod` to associate budgets with multiple periods. (`lib/budgie/tracking/budget.ex`, [lib/budgie/tracking/budget.exR15-R16](diffhunk://#diff-09bc532c992f449bc1623501f38386f7e836dff68eda8e9b291b420876599b61R15-R16))
* Created the `Budgie.Tracking.BudgetPeriod` schema to define the structure and constraints of budget periods, including validations for date boundaries. (`lib/budgie/tracking/budget_period.ex`, [lib/budgie/tracking/budget_period.exR1-R27](diffhunk://#diff-700ad6bdbabdcc47362f05fb23831790ce747f6b59be77a3a00a5fe8116ac502R1-R27))
* Added a migration to create the `budget_periods` table with constraints ensuring unique periods per budget and valid date ranges. (`priv/repo/migrations/20250421123312_create_budget_periods.exs`, [priv/repo/migrations/20250421123312_create_budget_periods.exsR1-R21](diffhunk://#diff-420173665ba8c9c2f28c3eb29ce35837edd0b44a19be6255500c2d016d63888fR1-R21))

### Validations and Logic:
* Introduced `Budgie.Validations.validate_date_month_boundaries` to enforce that start dates must be the beginning of a month and end dates must be the end of a month. (`lib/budgie/validations.ex`, [lib/budgie/validations.exR1-R23](diffhunk://#diff-064257d91bc54459e0ed2aa29f950dc5be5c5b8c8c91b66199d6ef89a86875d8R1-R23))
* Added logic in `Budgie.Tracking.Budget` to automatically generate and associate periods based on the budget's start and end dates. (`lib/budgie/tracking/budget.ex`, [lib/budgie/tracking/budget.exR31-R58](diffhunk://#diff-09bc532c992f449bc1623501f38386f7e836dff68eda8e9b291b420876599b61R31-R58))

### UI and User Experience Improvements:
* Updated `BudgieWeb.BudgetShowLive` to preload budget periods and display them in the budget details view. (`lib/budgie_web/live/budget_show_live.ex`, [[1]](diffhunk://#diff-731b06f0abeef1ae2e7896099e2814c884fdc8026914ea74616d80fa53e58ad4L33-R33); `lib/budgie_web/live/budget_show_live.html.heex`, [[2]](diffhunk://#diff-f46a58ebf0f8c34982af15188261879c556a998197ffd4a87f2410706a96b9c4R60-R72)
* Modified the budget creation dialog to navigate to the newly created budget's page upon successful creation. (`lib/budgie_web/live/create_budget_dialog.ex`, [lib/budgie_web/live/create_budget_dialog.exL32-R36](diffhunk://#diff-d20d51b2f40c8c520ab4c838f26b5f622a92811dcb13d8372dd051ea48a2f6c8L32-R36))

### Testing:
* Added unit tests for `Budgie.Tracking.BudgetPeriod` to validate date constraints and ensure correct behavior for valid and invalid inputs. (`test/budgie/tracking/budget_period_test.exs`, [test/budgie/tracking/budget_period_test.exsR1-R49](diffhunk://#diff-d9be78eea0cd7a49b7b3a9e83e328fb40a6173f36eaf847ebb547c5be7bbceb9R1-R49))
* Updated existing tests in `Budgie.TrackingTest` to reflect new date validation rules for budgets. (`test/budgie/tracking_test.exs`, [test/budgie/tracking_test.exsL45-R46](diffhunk://#diff-ae63ee6d998e71f38ae4ca6b496cf7582fc142d58375af7cf4c8145f0aac14a6L45-R46))
* Extended the factory to support `budget_period` creation for testing purposes. (`test/support/factory.ex`, [test/support/factory.exR31-R38](diffhunk://#diff-6cd03e1430edd4f8fc67bb60e7227bf5d504579052df7f9e1b9bc1596eb454b2R31-R38))